### PR TITLE
GitHub Actionsの実行環境でUbuntu/Node.js Latest LTSを使う

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "lts/*"
-      - id: yarn_cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn_cache.outputs.dir }}
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: yarn-
+          cache: yarn
       - run: yarn
       - run: yarn build
       - name: The working tree is clean.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
-        with: { node-version: 14 }
+        with:
+          node-version: "lts/*"
       - id: yarn_cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: "lts/*"
           cache: yarn
           registry-url: https://registry.npmjs.org/
       - run: yarn

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
     branches: [master]
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - id: yarn_cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,13 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - id: yarn_cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
+      - uses: actions/setup-node@v2
         with:
-          path: ${{ steps.yarn_cache.outputs.dir }}
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: yarn-
+          node-version: 14
+          cache: yarn
+          registry-url: https://registry.npmjs.org/
       - run: yarn
       - name: Git configuration.
         run: |
@@ -23,5 +21,6 @@ jobs:
         run: |
           npm version patch
           git push --atomic --tags origin HEAD
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
           npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
GitHub Actionsの実行環境で[Ubuntu LTS (現在20.04)](https://docs.github.com/ja/actions/reference/workflow-syntax-for-github-actions#) が指定可能なので対応します。
加えて[actions/setup-node](https://github.com/actions/setup-node#readmehttps://github.com/actions/setup-node#readme)でlts/*を指定可能になったので対応します。
またactions/setup-nodeではcacheを指定可能になったので対応し、いままでのactions/cacheの対応を削除します。

やったこと:

- use ubuntu-latest
- use actions/setup-node
- use latest lts node-version
- use actions/setup-node cache
